### PR TITLE
Potential fix for code scanning alert no. 4: Use of a broken or weak cryptographic hashing algorithm on sensitive data

### DIFF
--- a/blog/requirements.txt
+++ b/blog/requirements.txt
@@ -33,3 +33,4 @@ wcwidth==0.2.5
 Werkzeug==0.11.11
 wtf-peewee==0.2.6
 WTForms==2.1
+argon2-cffi==23.1.0

--- a/blog/user.py
+++ b/blog/user.py
@@ -5,7 +5,7 @@ from blog import auth
 from blog import db_util
 from blog.decorator import anonymous_required, login_required
 
-import hashlib
+from argon2 import PasswordHasher
 
 user = Blueprint('user', __name__, template_folder='templates')
 
@@ -51,7 +51,8 @@ class Register(MethodView):
             flash("Email Is Already Registered", "error")
             return render_template("auth/register.html", form_error="Email Is Already Registered")
 
-        hashed_password = hashlib.md5(password.encode()).hexdigest()
+        ph = PasswordHasher()
+        hashed_password = ph.hash(password)
 
         cur = db.connection.cursor()
         cur.execute(


### PR DESCRIPTION
Potential fix for [https://github.com/alexandroidii/dvpa/security/code-scanning/4](https://github.com/alexandroidii/dvpa/security/code-scanning/4)

To fix the problem, we need to replace the use of the MD5 hashing algorithm with a stronger, more secure algorithm suitable for password hashing. One of the best options is to use the `argon2` algorithm, which is designed to be computationally expensive and includes a per-password salt by default.

We will:
1. Install the `argon2-cffi` package if it is not already installed.
2. Import the `PasswordHasher` class from the `argon2` module.
3. Replace the MD5 hashing code with the `argon2` hashing code.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
